### PR TITLE
fix: Monotonic interpolator using Y instead of X

### DIFF
--- a/src/libInterpolate/Interpolators/_1D/MonotonicInterpolator.hpp
+++ b/src/libInterpolate/Interpolators/_1D/MonotonicInterpolator.hpp
@@ -141,7 +141,7 @@ MonotonicInterpolator<Real>::setupInterpolator()
 	else
 	{
 		// Determine the upper slope value
-		Real hhigh = Y(i+2) - xhigh;
+		Real hhigh = X(i+2) - xhigh;
 		Real slope_high = 0.0;
 		if (hhigh > 0.0)
 			slope_high = (Y(i+2) - yhigh)/hhigh;


### PR DESCRIPTION
I was getting strange results and tracked it down to this line that was using Y instead of X to calculate the upper slope. With this fix I'm getting the results I expected.

This makes it consistent with the operation for the lower slope on line 111.

Additionally, subtracting a Y value from an X value doesn't make sense because they are not on the same scale.