### PR TITLE
Fixed CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ install(
   EXPORT libInterpolateTargets
   FILE libInterpolateTargets.cmake
   NAMESPACE libInterpolate::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libInterpolate)
 file(
   WRITE ${CMAKE_CURRENT_BINARY_DIR}/libInterpolateConfig.cmake
   "include(CMakeFindDependencyMacro)
@@ -104,7 +104,7 @@ write_basic_package_version_file(
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/libInterpolateConfig.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/libInterpolateConfigVersion.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libInterpolate)
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
     "A C++ library for numerical interpolation.")


### PR DESCRIPTION
It seems that the current cmake configuration installs the `libInterpolateConfig.cmake` directly into the cmake directory (usually something like `/usr/local/cmake/`), as opposed to a dedicated subdirectory, i.e. `/usr/local/cmake/libInterpolate/`, which causes `find_package(libInterpolate REQUIRED)` to fail on my system. The pull request contains a quick fix for this