### PR TITLE
Added 2D Nearest Neighbor Interpolation. Fixed a small bug in 2D InterpolatorBase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libInterpolate/Interpolators/_2D/BilinearInterpolator.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libInterpolate/Interpolators/_2D/AnyInterpolator.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libInterpolate/Interpolators/_2D/BicubicInterpolator.hpp>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libInterpolate/Interpolators/_2D/NearestInterpolator.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libInterpolate/Interpolators/_1D/InterpolatorBase.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libInterpolate/Interpolators/_1D/CubicSplineInterpolator.hpp>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/libInterpolate/Interpolators/_1D/AnyInterpolator.hpp>

--- a/src/libInterpolate/Interpolate.hpp
+++ b/src/libInterpolate/Interpolate.hpp
@@ -6,3 +6,5 @@
 #include "./Interpolators/_2D/BicubicInterpolator.hpp"
 #include "./Interpolators/_2D/ThinPlateSplineInterpolator.hpp"
 #include "./Interpolators/_2D/LinearDelaunayTriangleInterpolator.hpp"
+#include "./Interpolators/_2D/NearestInterpolator.hpp"
+

--- a/src/libInterpolate/Interpolators/_2D/InterpolatorBase.hpp
+++ b/src/libInterpolate/Interpolators/_2D/InterpolatorBase.hpp
@@ -204,7 +204,7 @@ class InterpolatorBase
      */
   int get_x_index_to_right_of(Real x) const
   {
-    return this->get_x_index_to_right_of(x) + 1;
+    return this->get_x_index_to_left_of(x) + 1;
   }
 
   /**
@@ -225,7 +225,40 @@ class InterpolatorBase
   {
     return this->get_y_index_below(y) + 1;
   }
-
+  /**
+     * Given an x value, returns the index i of the stored x data X
+     * that is closest to x
+     */
+  int get_x_index_closest_to(Real x) const
+  {
+    // NOTE: X data is strided.
+    auto xrng = std::make_pair(X->data(), X->data() + X->size() * X->innerStride()) | boost::adaptors::strided(X->innerStride());
+    auto iter_lower = boost::lower_bound(xrng, x) - 1;
+    auto iter_upper = iter_lower + 1;
+    Real lower = *(iter_lower);
+    Real upper = *(iter_upper);
+    if (abs(x - lower) < abs(x - upper)) {
+        return iter_lower - boost::begin(xrng);
+    }
+    return iter_upper - boost::begin(xrng);
+  }
+   /**
+     * Given an y value, returns the index i of the stored y data Y
+     * that is closest to x
+     */
+  int get_y_index_closest_to(Real y) const
+  {
+    // NOTE: X data is strided.
+    auto yrng = std::make_pair(Y->data(), Y->data() + Y->size());
+    auto iter_lower = boost::lower_bound(yrng, y) - 1;
+    auto iter_upper = iter_lower + 1;
+    Real lower = *(iter_lower);
+    Real upper = *(iter_upper);
+    if (abs(y - lower) < abs(y - upper)) {
+        return iter_lower - boost::begin(yrng);
+    }
+    return iter_upper - boost::begin(yrng);
+  }
  protected:
   void checkData() const;   ///< Check that data has been initialized and throw exception if not.
   void setup2DDataViews();  ///< Setups up 2D views of 1D data arrays

--- a/src/libInterpolate/Interpolators/_2D/NearestInterpolator.hpp
+++ b/src/libInterpolate/Interpolators/_2D/NearestInterpolator.hpp
@@ -1,0 +1,83 @@
+#ifndef Interpolators__2D_NearestInterpolator_hpp
+#define Interpolators__2D_NearestInterpolator_hpp
+
+/** @file NearestInterpolator.hpp
+  * @brief 
+  * @author Finn Lukas Busch
+  * @date 10/10/23
+  */
+
+#include "InterpolatorBase.hpp"
+#include <boost/range/algorithm/lower_bound.hpp>
+#include <boost/range/adaptor/strided.hpp>
+
+/** @class 
+  * @brief Nearest interpolation for 2D functions.
+  * @author Finn Lukas Busch
+  */
+
+
+namespace _2D {
+    template<class Real>
+    class NearestInterpolator : public InterpolatorBase<NearestInterpolator<Real>> {
+    public:
+        using BASE = InterpolatorBase<NearestInterpolator<Real>>;
+    protected:
+        using BASE::xView;
+        using BASE::yView;
+        using BASE::zView;
+        using BASE::X;
+        using BASE::Y;
+        using BASE::Z;
+    public:
+
+        template<typename I>
+        NearestInterpolator( I n, Real *x, Real *y, Real *z ) {this->setData(n,x,y,z);}
+
+        template<typename X, typename Y, typename Z>
+        NearestInterpolator( X &x, Y &y, Z &z ) {this->setData(x,y,z);}
+
+        NearestInterpolator():BASE(){}
+        Real operator()( Real x, Real y ) const;
+
+        NearestInterpolator(const NearestInterpolator& rhs)
+                :BASE(rhs)
+        {}
+
+        // copy-swap idiom
+        friend void swap( NearestInterpolator& lhs, NearestInterpolator& rhs)
+        {
+            swap( static_cast<BASE&>(lhs), static_cast<BASE&>(rhs) );
+        }
+
+        NearestInterpolator& operator=(NearestInterpolator rhs)
+        {
+            swap(*this,rhs);
+            return *this;
+        }
+    };
+
+    template<class Real>
+    Real
+    NearestInterpolator<Real>::operator()( Real x, Real y ) const
+    {
+        BASE::checkData();
+        if( x < (*X)(0)
+            || x > (*X)(X->size()-1)
+            || y < (*Y)(0)
+            || y > (*Y)(Y->size()-1) )
+        {
+            return 0;
+        }
+        int i = this->get_x_index_closest_to(x);
+        int j = this->get_y_index_closest_to(y);
+
+        if(i < 0)
+            i = 0;
+        if(j < 0)
+            j = 0;
+        return Z->operator()(i, j);
+    }
+}
+
+#endif // include protector


### PR DESCRIPTION
Hi,

For my work, I needed nearest neighbor interpolation for 2D to display the "ground-truth" of the data. I implemented a simple interpolator that follows your code design and can be used like the other interpolators. For this, I added `get_x_index_to_closest_of`, and `get_y_index_to_closest_of` to the `_2D/InterpolatorBase.hpp` .
It is technically not really an interpolation technique, but I found it very useful to be able to switch between e.g. bicubic-interpolation and the "ground-truth" data. I updated `CMakeLists.txt` accordingly. I am not familiar with the other build systems which might need further adaptations.

 I also found a small bug in `_2D/InterpolatorBase.hpp` in `get_x_index_to_right_of`. 