### PR TITLE
chore: make OpenMP optional for unit tests.

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 find_package(GSL)
-find_package(OpenMP REQUIRED)
+find_package(OpenMP)
 find_package(Catch2 REQUIRED)
 # Find all sources.
 file(
@@ -20,7 +20,7 @@ add_executable(${testName} ${unitTest_SOURCES})
 target_compile_definitions(
   ${testName} PRIVATE TESTING $<$<TARGET_EXISTS:GSL::gsl>:HAVE_GSL>)
 target_link_libraries(${testName} Interpolate
-  $<$<TARGET_EXISTS:GSL::gsl>:GSL::gsl> OpenMP::OpenMP_CXX Catch2::Catch2WithMain)
+  $<$<TARGET_EXISTS:GSL::gsl>:GSL::gsl> $<$<TARGET_EXISTS:OpenMP::OpenMP_CXX>:OpenMP::OpenMP_CXX> Catch2::Catch2WithMain)
 set_target_properties(${testName} PROPERTIES CXX_STANDARD 17)
 if(MSVC)
   target_compile_options(${testName} PRIVATE /W4 -wd4996)


### PR DESCRIPTION
GitHub action is failing on MacOS because OpenMP is not available. No reason to require it for running tests.